### PR TITLE
Switch to a unicode whitespace aware method of trimming user provided Strings

### DIFF
--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/UIUtils.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/UIUtils.java
@@ -8,6 +8,7 @@ import android.os.Build.VERSION_CODES;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
 import android.support.v4.view.GestureDetectorCompat;
 import android.util.TypedValue;
 import android.view.GestureDetector;
@@ -194,6 +195,16 @@ public class UIUtils {
     /** Normalize a string for hue hash processing */
     private static String normalize(String text) {
         return EMOJI_RE.matcher(text).replaceAll("").replaceAll("[^\\w_\\-]", "").toLowerCase();
+    }
+
+    /**
+     * Trim all unicode whitespace characters from the start and end of the passed String.
+     *
+     * String::trim() uses a non-unicode-aware (or only partially so) concept of whitespace characters.
+     */
+    @NonNull
+    public static String trimUnicodeWhitespace(@NonNull String text) {
+        return text.replaceAll("^\\p{Z}+|\\p{Z}+$", "");
     }
 
     /**

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/UIUtils.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/UIUtils.java
@@ -37,6 +37,8 @@ public class UIUtils {
     public static final float COLOR_AT_SATURATION = 0.42f;
     public static final float COLOR_AT_LIGHTNESS = 0.50f;
 
+    private static final Pattern WHITESPACE_TRIMMING_RE = Pattern.compile("^\\p{Z}+|\\p{Z}+$");
+
     // TODO check against actual list of valid emoji
     private static final Pattern EMOJI_RE = Pattern.compile(":[a-zA-Z!?\\-]+?:");
 
@@ -204,7 +206,7 @@ public class UIUtils {
      */
     @NonNull
     public static String trimUnicodeWhitespace(@NonNull String text) {
-        return text.replaceAll("^\\p{Z}+|\\p{Z}+$", "");
+        return WHITESPACE_TRIMMING_RE.matcher(text).replaceAll("");
     }
 
     /**

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/UIUtils.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/UIUtils.java
@@ -203,6 +203,9 @@ public class UIUtils {
      * Trim all unicode whitespace characters from the start and end of the passed String.
      *
      * String::trim() uses a non-unicode-aware (or only partially so) concept of whitespace characters.
+     * 
+     * @param text The string to be trimmed
+     * @return The passed string with all whitespace characters at the start and end of it removed
      */
     @NonNull
     public static String trimUnicodeWhitespace(@NonNull String text) {

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/InputBarView.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/InputBarView.java
@@ -167,13 +167,6 @@ public class InputBarView extends BaseMessageView {
     }
 
     private void doNickChange() {
-        // Strip whitespace
-        Editable nickEditor = nickEntry.getText();
-        String newNick = nickEditor.toString();
-        String trimmedNick = trimUnicodeWhitespace(newNick);
-        if (!newNick.equals(trimmedNick)) {
-            nickEditor.replace(0, newNick.length(), trimmedNick);
-        }
         // Invoke listener
         if (nickChangeListener != null && !nickChangeListener.onChangeNick(this)) {
             nickEntry.setText(lastNick);

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/InputBarView.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/InputBarView.java
@@ -16,6 +16,7 @@ import static io.euphoria.xkcd.app.impl.ui.UIUtils.hslToRgbInt;
 import static io.euphoria.xkcd.app.impl.ui.UIUtils.nickColor;
 import static io.euphoria.xkcd.app.impl.ui.UIUtils.setColoredBackground;
 import static io.euphoria.xkcd.app.impl.ui.UIUtils.setEnterKeyListener;
+import static io.euphoria.xkcd.app.impl.ui.UIUtils.trimUnicodeWhitespace;
 
 public class InputBarView extends BaseMessageView {
 
@@ -169,7 +170,7 @@ public class InputBarView extends BaseMessageView {
         // Strip whitespace
         Editable nickEditor = nickEntry.getText();
         String newNick = nickEditor.toString();
-        String trimmedNick = newNick.trim();
+        String trimmedNick = trimUnicodeWhitespace(newNick);
         if (!newNick.equals(trimmedNick)) {
             nickEditor.replace(0, newNick.length(), trimmedNick);
         }

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/MessageView.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/MessageView.java
@@ -18,6 +18,7 @@ import static io.euphoria.xkcd.app.impl.ui.UIUtils.hslToRgbInt;
 import static io.euphoria.xkcd.app.impl.ui.UIUtils.isEmote;
 import static io.euphoria.xkcd.app.impl.ui.UIUtils.setColoredBackground;
 import static io.euphoria.xkcd.app.impl.ui.UIUtils.setViewBackground;
+import static io.euphoria.xkcd.app.impl.ui.UIUtils.trimUnicodeWhitespace;
 
 public class MessageView extends BaseMessageView {
 
@@ -50,7 +51,7 @@ public class MessageView extends BaseMessageView {
             String content = msg.getContent();
             boolean emote = isEmote(content);
             String displayContent = emote ? content.substring(3) : content;
-            displayContent = displayContent.trim();
+            displayContent = trimUnicodeWhitespace(displayContent);
             // Apply the nickname
             nickLbl.updateParameters(emote, msg.getSenderName());
             // Apply the message's text


### PR DESCRIPTION
Java's `String::trim` method does not trim a lot of unicode whitespace characters resulting in euphoria.leet.nu whitespace encoded messages being displayed in an undesirable way. Using `String::replaceAll` with a regex matching all unicode whitespace at the start and end of a String instead resolves these issues.