### PR TITLE
Pass changes of the own nickname to the UI

### DIFF
--- a/app/src/main/java/io/euphoria/xkcd/app/RoomActivity.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/RoomActivity.java
@@ -237,8 +237,9 @@ public class RoomActivity extends AppCompatActivity {
         inputBar.setNickChangeListener(new InputBarView.NickChangeListener() {
             @Override
             public boolean onChangeNick(InputBarView view) {
-                final String text = view.getNickText();
+                final String text = view.getNextNick();
                 if (text.isEmpty() || roomUI.getConnectionStatus() != ConnectionStatus.CONNECTED) return false;
+                if (text.equals(view.getConfirmedNick())) return true;
                 roomUI.submitEvent(new NewNickEvent() {
                     @Override
                     public String getNewNick() {

--- a/app/src/main/java/io/euphoria/xkcd/app/RoomActivity.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/RoomActivity.java
@@ -8,7 +8,6 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.widget.DrawerLayout;
-import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -233,7 +232,7 @@ public class RoomActivity extends AppCompatActivity {
         });
 
         // Controller etc. setup
-        roomUI.link(statusDisplay, messageAdapter, userListAdapter);
+        roomUI.link(statusDisplay, messageAdapter, userListAdapter, inputBar);
         roomController.openRoom(roomName);
         inputBar.setNickChangeListener(new InputBarView.NickChangeListener() {
             @Override
@@ -332,7 +331,7 @@ public class RoomActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        roomUI.unlink(statusDisplay, messageAdapter, userListAdapter);
+        roomUI.unlink(statusDisplay, messageAdapter, userListAdapter, inputBar);
         roomController.closeRoom(roomUI.getRoomName());
         roomController.getRoomUIManager().setRoomUIFactory(null);
         roomController.shutdown();

--- a/app/src/main/java/io/euphoria/xkcd/app/control/RoomController.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/control/RoomController.java
@@ -109,6 +109,7 @@ public class RoomController {
                 invokeLater(new Runnable() {
                     @Override
                     public void run() {
+                        ui.setIdentity(evt.getIdentity());
                         ui.showNicks(Collections.singletonList(evt.getIdentity()));
                     }
                 });

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/connection/EuphoriaWebSocketClient.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/connection/EuphoriaWebSocketClient.java
@@ -305,7 +305,7 @@ public class EuphoriaWebSocketClient extends WebSocketClient {
         this.ready = false;
         this.closed = false;
         this.sessionID = null;
-        this.confirmedNick = null;
+        this.confirmedNick = "";
     }
 
     public ConnectionImpl getParent() {

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/connection/EuphoriaWebSocketClient.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/connection/EuphoriaWebSocketClient.java
@@ -383,6 +383,7 @@ public class EuphoriaWebSocketClient extends WebSocketClient {
                     } else {
                         Log.w("EuphoriaWebSocketClient", "Unknown network-event subtype: " + subtype);
                     }
+                    break;
                 case "nick-event": case "nick-reply":
                     String newNick;
                     ServerSessionView session;

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/connection/EuphoriaWebSocketClient.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/connection/EuphoriaWebSocketClient.java
@@ -294,6 +294,8 @@ public class EuphoriaWebSocketClient extends WebSocketClient {
     private final Queue<String> sendaheadQueue;
     private boolean ready;
     private boolean closed;
+    private String sessionID;
+    private String confirmedNick;
 
     public EuphoriaWebSocketClient(ConnectionImpl parent, URI endpoint) {
         super(endpoint);
@@ -302,6 +304,8 @@ public class EuphoriaWebSocketClient extends WebSocketClient {
         this.sendaheadQueue = new ArrayDeque<>();
         this.ready = false;
         this.closed = false;
+        this.sessionID = null;
+        this.confirmedNick = null;
     }
 
     public ConnectionImpl getParent() {
@@ -353,7 +357,9 @@ public class EuphoriaWebSocketClient extends WebSocketClient {
                             .toString());
                     break;
                 case "hello-event":
-                    submitEvent(new IdentityEventImpl(parseSessionView(data.getJSONObject("session"))));
+                    ServerSessionView identity = parseSessionView(data.getJSONObject("session"));
+                    sessionID = identity.getSessionID();
+                    submitEvent(new IdentityEventImpl(identity));
                     dispatchReady();
                     break;
                 case "join-event":
@@ -378,14 +384,32 @@ public class EuphoriaWebSocketClient extends WebSocketClient {
                         Log.w("EuphoriaWebSocketClient", "Unknown network-event subtype: " + subtype);
                     }
                 case "nick-event": case "nick-reply":
-                    ServerSessionView session = sessions.get(data.getString("session_id"));
-                    if (session == null) {
-                        Log.e("EuphoriaWebSocketClient", "Dropping nick change of unknown session ID " +
-                                data.getString("session_id") + "!");
-                        break;
+                    String newNick;
+                    ServerSessionView session;
+                    if (data == null) {
+                        // Error: The server rejected a nickname change -- roll back to the latest confirmed nick.
+                        if (type.equals("nick-event")) {
+                            Log.e("EuphoriaWebSocketClient", "nick-event contains no data?!");
+                            break;
+                        }
+                        newNick = confirmedNick;
+                        session = sessions.get(sessionID);
+                        if (session == null) {
+                            Log.e("EuphoriaWebSocketClient",
+                                    "Cannot locate our own session while processing a failed nick-reply?!");
+                            break;
+                        }
+                    } else {
+                        newNick = data.getString("to");
+                        confirmedNick = newNick;
+                        session = sessions.get(data.getString("session_id"));
+                        if (session == null) {
+                            Log.e("EuphoriaWebSocketClient", "Dropping nick change of unknown session ID " +
+                                    data.getString("session_id") + "!");
+                            break;
+                        }
                     }
-                    submitEvent(new NickChangeEventImpl(new SessionViewImpl(session, data.getString("to")),
-                            session.getName()));
+                    submitEvent(new NickChangeEventImpl(new SessionViewImpl(session, newNick), session.getName()));
                     break;
                 case "part-event":
                     submitEvent(new PresenceChangeEventImpl(Collections.singletonList(parseSessionView(data)),

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/RoomUIImpl.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/RoomUIImpl.java
@@ -15,6 +15,7 @@ import io.euphoria.xkcd.app.connection.ConnectionStatus;
 import io.euphoria.xkcd.app.data.Message;
 import io.euphoria.xkcd.app.data.SessionView;
 import io.euphoria.xkcd.app.impl.ui.data.UIMessage;
+import io.euphoria.xkcd.app.impl.ui.views.InputBarView;
 import io.euphoria.xkcd.app.impl.ui.views.MessageListAdapter;
 import io.euphoria.xkcd.app.impl.ui.views.UserListAdapter;
 import io.euphoria.xkcd.app.ui.RoomUI;
@@ -30,9 +31,11 @@ public class RoomUIImpl implements RoomUI {
 
     private final String roomName;
     private final Set<UIListener> listeners = new LinkedHashSet<>();
+    private SessionView identity;
     private TextView statusDisplay;
     private MessageListAdapter messagesAdapter;
     private UserListAdapter usersAdapter;
+    private InputBarView inputBar;
 
     public RoomUIImpl(String roomName) {
         this.roomName = roomName;
@@ -85,6 +88,11 @@ public class RoomUIImpl implements RoomUI {
     }
 
     @Override
+    public void setIdentity(SessionView identity) {
+        this.identity = identity;
+    }
+
+    @Override
     public void showMessages(List<Message> messages) {
         for (Message m : messages) {
             messagesAdapter.add(new UIMessage(m));
@@ -94,6 +102,11 @@ public class RoomUIImpl implements RoomUI {
     @Override
     public void showNicks(List<SessionView> sessions) {
         usersAdapter.getData().addAll(sessions);
+        for (SessionView s : sessions) {
+            if (s.getSessionID().equals(identity.getSessionID())) {
+                inputBar.setNickText(s.getName());
+            }
+        }
     }
 
     @Override
@@ -129,16 +142,18 @@ public class RoomUIImpl implements RoomUI {
         Log.e("RoomUIImpl", detail + " is not yet implemented...");
     }
 
-    public void link(TextView status, MessageListAdapter messages, UserListAdapter users) {
+    public void link(TextView status, MessageListAdapter messages, UserListAdapter users, InputBarView input) {
         statusDisplay = status;
         messagesAdapter = messages;
         usersAdapter = users;
+        inputBar = input;
     }
 
-    public void unlink(TextView status, MessageListAdapter messages, UserListAdapter users) {
+    public void unlink(TextView status, MessageListAdapter messages, UserListAdapter users, InputBarView input) {
         if (statusDisplay == status) statusDisplay = null;
         if (messagesAdapter == messages) messagesAdapter = null;
         if (usersAdapter == users) usersAdapter = null;
+        if (inputBar == input) inputBar = null;
     }
 
     public void submitEvent(UIEvent evt) {

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/RoomUIImpl.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/RoomUIImpl.java
@@ -104,7 +104,7 @@ public class RoomUIImpl implements RoomUI {
         usersAdapter.getData().addAll(sessions);
         for (SessionView s : sessions) {
             if (s.getSessionID().equals(identity.getSessionID())) {
-                inputBar.setNickText(s.getName());
+                inputBar.setAllNicks(s.getName());
             }
         }
     }

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/InputBarView.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/InputBarView.java
@@ -32,6 +32,7 @@ public class InputBarView extends BaseMessageView {
     }
 
     private final MarginLayoutParams defaultLayoutParams;
+    private String confirmedNick;
     private String lastNick;
     private EditText nickEntry;
     private EditText messageEntry;
@@ -104,6 +105,10 @@ public class InputBarView extends BaseMessageView {
         // TODO state saving should go here
     }
 
+    public String getConfirmedNick() {
+        return confirmedNick;
+    }
+
     public String getLastNick() {
         return lastNick;
     }
@@ -132,12 +137,14 @@ public class InputBarView extends BaseMessageView {
         this.nickChangeListener = nickChangeListener;
     }
 
-    public String getNickText() {
+    public String getNextNick() {
         return nickEntry.getText().toString();
     }
 
-    public void setNickText(String newNick) {
-        nickEntry.setText(newNick);
+    public void setAllNicks(String nick) {
+        confirmedNick = nick;
+        lastNick = nick;
+        nickEntry.setText(nick);
     }
 
     public String getMessageText() {

--- a/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/InputBarView.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/impl/ui/views/InputBarView.java
@@ -16,7 +16,6 @@ import static io.euphoria.xkcd.app.impl.ui.UIUtils.hslToRgbInt;
 import static io.euphoria.xkcd.app.impl.ui.UIUtils.nickColor;
 import static io.euphoria.xkcd.app.impl.ui.UIUtils.setColoredBackground;
 import static io.euphoria.xkcd.app.impl.ui.UIUtils.setEnterKeyListener;
-import static io.euphoria.xkcd.app.impl.ui.UIUtils.trimUnicodeWhitespace;
 
 public class InputBarView extends BaseMessageView {
 
@@ -135,6 +134,10 @@ public class InputBarView extends BaseMessageView {
 
     public String getNickText() {
         return nickEntry.getText().toString();
+    }
+
+    public void setNickText(String newNick) {
+        nickEntry.setText(newNick);
     }
 
     public String getMessageText() {

--- a/app/src/main/java/io/euphoria/xkcd/app/ui/RoomUI.java
+++ b/app/src/main/java/io/euphoria/xkcd/app/ui/RoomUI.java
@@ -29,6 +29,9 @@ public interface RoomUI {
      */
     void setConnectionStatus(ConnectionStatus status);
 
+    /* Set the identity of the user this UI acts as */
+    void setIdentity(SessionView identity);
+
     /* Display the given messages
      *
      * If a message in the list is already visible (as determined by the message ID), it is to be replaced.


### PR DESCRIPTION
While the first commit implements the goal stated in the title, I discovered that the UI code also creates nick change events unconditionally — together with the changes here, nasty infinite loops could ensue. Hence, this PR will also add proper avoid-firing-listeners-when-the-value-did-not-actually-change behavior.

Closes #10.